### PR TITLE
Add encoding when reading the README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup
 
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 


### PR DESCRIPTION
Running on Windows throws the following error: `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 776: character maps to <undefined>`, when doing `long_description = fh.read()`